### PR TITLE
Update Bower file name

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -9,7 +9,7 @@ module.exports = function(grunt) {
   grunt.initConfig({
 
     meta: {
-      version: '0.2.1',
+      version: '0.2.2',
       banner: '// Big Bird\n// v<%= meta.version %>\n// by @cjbell88, @ninjabiscuit & @callumj_ all from @madebymany'
     },
 

--- a/bigbird.js
+++ b/bigbird.js
@@ -8,7 +8,7 @@
   var BigBird = window.BigBird = {};
 
   // Current version of BigBird
-  BigBird.VERSION = '0.2.1';
+  BigBird.VERSION = '0.2.2';
 
   // Use jQuery (our only dependency)
   var $ = window.jQuery || window.Zepto || window.ender || window.$;

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "BigBird",
-  "version": "0.2.0",
+  "version": "0.2.2",
   "main": "bigbird.js",
   "ignore": [
     "**/.*",


### PR DESCRIPTION
I installed BigBird with Bower and it seemed to make my project default to using `component.json` instead of the updated `bower.json`.

There was also a version mismatch, so I bumped the version and made sure that was updated everywhere.

```
callum:stream-module $ bower install bigbird
bower cloning git://github.com/madebymany/bigbird.git
bower cached git://github.com/madebymany/bigbird.git
bower fetching bigbird
bower checking out bigbird#0.2.1
bower copying /Users/madebymany/.bower/cache/bigbird/c48f80b59c84a20274e001dc66f07601
mismatch The version specified in the component.json of package bigbird mismatches the tag (0.2.1 vs 0.2.0)
mismatch You should report this problem to the package author
bower installing bigbird#0.2.1
```
